### PR TITLE
ARTEMIS-4658 AMQP federation example for multicast over hub and spoke

### DIFF
--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/pom.xml
@@ -1,0 +1,237 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <artifactId>broker-connections</artifactId>
+      <version>2.33.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>amqp-federation-multicast-hub-spoke</artifactId>
+   <packaging>jar</packaging>
+   <name>amqp-federation</name>
+
+   <properties>
+      <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
+   </properties>
+
+   <dependencies>
+      <dependency>
+         <groupId>org.apache.qpid</groupId>
+         <artifactId>qpid-jms-client</artifactId>
+      </dependency>
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-maven-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>createHub</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <instance>${basedir}/target/hub</instance>
+                     <allowAnonymous>true</allowAnonymous>
+                     <configuration>${basedir}/target/classes/activemq/hub</configuration>
+                     <!-- this makes it easier in certain envs -->
+                     <javaOptions>-Djava.net.preferIPv4Stack=true</javaOptions>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>createSpoke1</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <instance>${basedir}/target/spoke1</instance>
+                     <allowAnonymous>true</allowAnonymous>
+                     <configuration>${basedir}/target/classes/activemq/spoke1</configuration>
+                     <!-- this makes it easier in certain envs -->
+                     <javaOptions>-Djava.net.preferIPv4Stack=true</javaOptions>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>createSpoke2</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <instance>${basedir}/target/spoke2</instance>
+                     <allowAnonymous>true</allowAnonymous>
+                     <configuration>${basedir}/target/classes/activemq/spoke2</configuration>
+                     <!-- this makes it easier in certain envs -->
+                     <javaOptions>-Djava.net.preferIPv4Stack=true</javaOptions>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>createSpoke3</id>
+                  <goals>
+                     <goal>create</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <instance>${basedir}/target/spoke3</instance>
+                     <allowAnonymous>true</allowAnonymous>
+                     <configuration>${basedir}/target/classes/activemq/spoke3</configuration>
+                     <!-- this makes it easier in certain envs -->
+                     <javaOptions>-Djava.net.preferIPv4Stack=true</javaOptions>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>startHub</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <spawn>true</spawn>
+                     <location>${basedir}/target/hub</location>
+                     <testURI>tcp://localhost:5460</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                     <name>hub</name>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>startSpoke3</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <spawn>true</spawn>
+                     <location>${basedir}/target/spoke3</location>
+                     <testURI>tcp://localhost:5860</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                     <name>spoke3</name>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>startSpoke2</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <spawn>true</spawn>
+                     <location>${basedir}/target/spoke2</location>
+                     <testURI>tcp://localhost:5760</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                     <name>spoke2</name>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>startSpoke1</id>
+                  <goals>
+                     <goal>cli</goal>
+                  </goals>
+                  <configuration>
+                     <spawn>true</spawn>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/spoke1</location>
+                     <testURI>tcp://localhost:5660</testURI>
+                     <args>
+                        <param>run</param>
+                     </args>
+                     <name>spoke1</name>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>runClient</id>
+                  <goals>
+                     <goal>runClient</goal>
+                  </goals>
+                  <configuration>
+                     <!-- you may have to set export MAVEN_OPTS="-Djava.net.preferIPv4Stack=true"
+                          if you are on MacOS for instance -->
+                     <clientClass>org.apache.activemq.artemis.jms.example.BrokerFederationExample</clientClass>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stopSpoke1</id>
+                  <goals>
+                     <goal>stop</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/spoke1</location>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stopSpoke2</id>
+                  <goals>
+                     <goal>stop</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/spoke2</location>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stopSpoke3</id>
+                  <goals>
+                     <goal>stop</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/spoke3</location>
+                  </configuration>
+               </execution>
+               <execution>
+                  <id>stopHub</id>
+                  <goals>
+                     <goal>stop</goal>
+                  </goals>
+                  <configuration>
+                     <ignore>${noServer}</ignore>
+                     <location>${basedir}/target/hub</location>
+                  </configuration>
+               </execution>
+            </executions>
+            <dependencies>
+               <dependency>
+                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <artifactId>amqp-federation-multicast-hub-spoke</artifactId>
+                  <version>${project.version}</version>
+               </dependency>
+            </dependencies>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-clean-plugin</artifactId>
+         </plugin>
+      </plugins>
+   </build>
+</project>

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/readme.md
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/readme.md
@@ -1,0 +1,5 @@
+# AMQP Federation example of multicast hub and spoke configuration
+
+To run the example, simply type **mvn verify** from this directory, or **mvn -PnoServer verify** if you want to create and start the broker manually.
+
+This example demonstrates how you can federate messages over multicast addresses in a hub and spoke topology.

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/java/org/apache/activemq/artemis/jms/example/BrokerFederationExample.java
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/java/org/apache/activemq/artemis/jms/example/BrokerFederationExample.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.jms.example;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+
+import org.apache.qpid.jms.JmsConnectionFactory;
+
+/**
+ * This example is demonstrating how messages are federated across a multicast
+ * address with a set of brokers in a hub and spoke arrangement with each spoke
+ * broker having bi-directional federation linking them to the hub. Messages in this
+ * example are produced and consumed on the spokes and on the hub, any message sent
+ * on one of the spokes or on the hub is available to any consumer on any other spoke
+ * or at the hub as well as a consumer on the source.
+ */
+public class BrokerFederationExample {
+
+   public static void main(final String[] args) throws Exception {
+
+      final ConnectionFactory connectionFactoryHub = new JmsConnectionFactory("amqp://localhost:5460");
+      final ConnectionFactory connectionFactorySpoke1 = new JmsConnectionFactory("amqp://localhost:5660");
+      final ConnectionFactory connectionFactorySpoke2 = new JmsConnectionFactory("amqp://localhost:5760");
+      final ConnectionFactory connectionFactorySpoke3 = new JmsConnectionFactory("amqp://localhost:5860");
+
+      final Connection connectionOnHub = connectionFactoryHub.createConnection(); // Hub
+      final Connection connectionOnSpoke1 = connectionFactorySpoke1.createConnection(); // Spoke 1
+      final Connection connectionOnSpoke2 = connectionFactorySpoke2.createConnection(); // Spoke 2
+      final Connection connectionOnSpoke3 = connectionFactorySpoke3.createConnection(); // Spoke 3
+
+      connectionOnHub.start();
+      connectionOnSpoke1.start();
+      connectionOnSpoke2.start();
+      connectionOnSpoke3.start();
+
+      final Session sessionOnHub = connectionOnHub.createSession(Session.AUTO_ACKNOWLEDGE);
+      final Session sessionOnSpoke1 = connectionOnSpoke1.createSession(Session.AUTO_ACKNOWLEDGE);
+      final Session sessionOnSpoke2 = connectionOnSpoke2.createSession(Session.AUTO_ACKNOWLEDGE);
+      final Session sessionOnSpoke3 = connectionOnSpoke3.createSession(Session.AUTO_ACKNOWLEDGE);
+
+      final Topic ordersTopic = sessionOnSpoke1.createTopic("orders");
+
+      final MessageConsumer ordersConsumerOnHub = sessionOnHub.createConsumer(ordersTopic);
+      final MessageConsumer ordersConsumerOn1 = sessionOnSpoke1.createConsumer(ordersTopic);
+      final MessageConsumer ordersConsumerOn2 = sessionOnSpoke2.createConsumer(ordersTopic);
+      final MessageConsumer ordersConsumerOn3 = sessionOnSpoke3.createConsumer(ordersTopic);
+
+      System.out.println("Starting example to produce and consume on hub and spoke brokers");
+
+      // Producer on any given spoke or the hub should propagate to all consumers on all nodes
+      final MessageProducer ordersProducerOnHub = sessionOnHub.createProducer(ordersTopic);
+      final MessageProducer ordersProducerOn1 = sessionOnSpoke1.createProducer(ordersTopic);
+      final MessageProducer ordersProducerOn2 = sessionOnSpoke2.createProducer(ordersTopic);
+      final MessageProducer ordersProducerOn3 = sessionOnSpoke3.createProducer(ordersTopic);
+
+      Thread.sleep(5000); // Allow time for federation links to be created.
+
+      // Receive Message sent on spoke 1
+      {
+         ordersProducerOn1.send(sessionOnSpoke1.createTextMessage("message #1 from spoke 1"));
+
+         final Message receivedHub = ordersConsumerOnHub.receive(10_000);
+         final Message received1 = ordersConsumerOn1.receive(10_000);
+         final Message received2 = ordersConsumerOn2.receive(10_000);
+         final Message received3 = ordersConsumerOn3.receive(10_000);
+
+         if (receivedHub == null) {
+            System.out.println("Did not receive message on Hub that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) receivedHub;
+            System.out.println("Received message on the Hub : " + mssage.getText());
+         }
+
+         if (received1 == null) {
+            System.out.println("Did not receive message on spoke 1 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received1;
+            System.out.println("Received message on spoke 1 : " + mssage.getText());
+         }
+
+         if (received2 == null) {
+            System.out.println("Did not receive message on spoke 2 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received2;
+            System.out.println("Received message on spoke 2 : " + mssage.getText());
+         }
+
+         if (received3 == null) {
+            System.out.println("Did not receive message on spoke 3 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received3;
+            System.out.println("Received message on spoke 3 : " + mssage.getText());
+         }
+      }
+
+      // Receive Message sent on spoke 2
+      {
+         ordersProducerOn2.send(sessionOnSpoke2.createTextMessage("message #2 from spoke 2"));
+
+         final Message receivedHub = ordersConsumerOnHub.receive(10_000);
+         final Message received1 = ordersConsumerOn1.receive(10_000);
+         final Message received2 = ordersConsumerOn2.receive(10_000);
+         final Message received3 = ordersConsumerOn3.receive(10_000);
+
+         if (receivedHub == null) {
+            System.out.println("Did not receive message on Hub that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) receivedHub;
+            System.out.println("Received message on the Hub : " + mssage.getText());
+         }
+
+         if (received1 == null) {
+            System.out.println("Did not receive message on spoke 1 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received1;
+            System.out.println("Received message on spoke 1 : " + mssage.getText());
+         }
+
+         if (received2 == null) {
+            System.out.println("Did not receive message on spoke 2 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received2;
+            System.out.println("Received message on spoke 2 : " + mssage.getText());
+         }
+
+         if (received3 == null) {
+            System.out.println("Did not receive message on spoke 3 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received3;
+            System.out.println("Received message on spoke 3 : " + mssage.getText());
+         }
+      }
+
+      // Receive Message sent on spoke 3
+      {
+         ordersProducerOn3.send(sessionOnSpoke3.createTextMessage("message #3 from spoke 3"));
+
+         final Message receivedHub = ordersConsumerOnHub.receive(10_000);
+         final Message received1 = ordersConsumerOn1.receive(10_000);
+         final Message received2 = ordersConsumerOn2.receive(10_000);
+         final Message received3 = ordersConsumerOn3.receive(10_000);
+
+         if (receivedHub == null) {
+            System.out.println("Did not receive message on Hub that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) receivedHub;
+            System.out.println("Received message on the Hub : " + mssage.getText());
+         }
+
+         if (received1 == null) {
+            System.out.println("Did not receive message on spoke 1 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received1;
+            System.out.println("Received message on spoke 1 : " + mssage.getText());
+         }
+
+         if (received2 == null) {
+            System.out.println("Did not receive message on spoke 2 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received2;
+            System.out.println("Received message on spoke 2 : " + mssage.getText());
+         }
+
+         if (received3 == null) {
+            System.out.println("Did not receive message on spoke 3 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received3;
+            System.out.println("Received message on spoke 3 : " + mssage.getText());
+         }
+      }
+
+      // Receive Message sent on Hub
+      {
+         ordersProducerOnHub.send(sessionOnHub.createTextMessage("message #4 from hub"));
+
+         final Message receivedHub = ordersConsumerOnHub.receive(10_000);
+         final Message received1 = ordersConsumerOn1.receive(10_000);
+         final Message received2 = ordersConsumerOn2.receive(10_000);
+         final Message received3 = ordersConsumerOn3.receive(10_000);
+
+         if (receivedHub == null) {
+            System.out.println("Did not receive message on Hub that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) receivedHub;
+            System.out.println("Received message on the Hub : " + mssage.getText());
+         }
+
+         if (received1 == null) {
+            System.out.println("Did not receive message on spoke 1 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received1;
+            System.out.println("Received message on spoke 1 : " + mssage.getText());
+         }
+
+         if (received2 == null) {
+            System.out.println("Did not receive message on spoke 2 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received2;
+            System.out.println("Received message on spoke 2 : " + mssage.getText());
+         }
+
+         if (received3 == null) {
+            System.out.println("Did not receive message on spoke 3 that was expected");
+         } else {
+            final TextMessage mssage = (TextMessage) received3;
+            System.out.println("Received message on spoke 3 : " + mssage.getText());
+         }
+      }
+   }
+}

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/hub/broker.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/hub/broker.xml
@@ -1,0 +1,101 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>Hub</name>
+
+      <persistence-enabled>false</persistence-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      <page-sync-timeout>44000</page-sync-timeout>
+
+      <acceptors>
+         <!-- Acceptor for every supported protocol -->
+         <acceptor name="artemis">tcp://0.0.0.0:5460?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true</acceptor>
+      </acceptors>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="createDurableQueue" roles="guest"/>
+            <permission type="deleteDurableQueue" roles="guest"/>
+            <permission type="createAddress" roles="guest"/>
+            <permission type="deleteAddress" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="browse" roles="guest"/>
+            <permission type="send" roles="guest"/>
+            <permission type="manage" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!-- if you define auto-create on certain queues, management has to be auto-create -->
+         <address-setting match="activemq.management#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+      </address-settings>
+
+      <addresses>
+         <address name="orders">
+            <multicast>
+            </multicast>
+         </address>
+      </addresses>
+
+   </core>
+</configuration>

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/spoke1/broker.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/spoke1/broker.xml
@@ -1,0 +1,118 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>Spoke1</name>
+
+      <persistence-enabled>false</persistence-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      <page-sync-timeout>44000</page-sync-timeout>
+
+      <acceptors>
+         <!-- Acceptor for every supported protocol -->
+         <acceptor name="artemis">tcp://0.0.0.0:5660?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true</acceptor>
+      </acceptors>
+
+      <broker-connections>
+         <amqp-connection uri="tcp://localhost:5460" name="federation-example-spoke-1" retry-interval="100">
+            <!-- This will create a federation connection between servers, the local
+                 server will federate messages sent to the address 'orders' from the
+                 remote and the remote will federate message sent to the address 'orders'
+                 on the local broker to itself. -->
+            <federation>
+               <local-address-policy name="address-federation-from-remote" max-hops="2">
+                  <include address-match="orders" />
+               </local-address-policy>
+               <remote-address-policy name="address-federation-to-remote" max-hops="2">
+                  <include address-match="orders" />
+               </remote-address-policy>
+             </federation>
+         </amqp-connection>
+      </broker-connections>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="createDurableQueue" roles="guest"/>
+            <permission type="deleteDurableQueue" roles="guest"/>
+            <permission type="createAddress" roles="guest"/>
+            <permission type="deleteAddress" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="browse" roles="guest"/>
+            <permission type="send" roles="guest"/>
+            <permission type="manage" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!-- if you define auto-create on certain queues, management has to be auto-create -->
+         <address-setting match="activemq.management#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+      </address-settings>
+
+      <addresses>
+         <address name="orders">
+            <multicast>
+            </multicast>
+         </address>
+      </addresses>
+
+   </core>
+</configuration>

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/spoke2/broker.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/spoke2/broker.xml
@@ -1,0 +1,118 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>Spoke2</name>
+
+      <persistence-enabled>false</persistence-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      <page-sync-timeout>44000</page-sync-timeout>
+
+      <acceptors>
+         <!-- Acceptor for every supported protocol -->
+         <acceptor name="artemis">tcp://0.0.0.0:5760?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true</acceptor>
+      </acceptors>
+
+      <broker-connections>
+         <amqp-connection uri="tcp://localhost:5460" name="federation-example-spoke-2" retry-interval="100">
+            <!-- This will create a federation connection between servers, the local
+                 server will federate messages sent to the address 'orders' from the
+                 remote and the remote will federate message sent to the address 'orders'
+                 on the local broker to itself. -->
+            <federation>
+               <local-address-policy name="address-federation-from-remote" max-hops="2">
+                  <include address-match="orders" />
+               </local-address-policy>
+               <remote-address-policy name="address-federation-to-remote" max-hops="2">
+                  <include address-match="orders" />
+               </remote-address-policy>
+             </federation>
+         </amqp-connection>
+      </broker-connections>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="createDurableQueue" roles="guest"/>
+            <permission type="deleteDurableQueue" roles="guest"/>
+            <permission type="createAddress" roles="guest"/>
+            <permission type="deleteAddress" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="browse" roles="guest"/>
+            <permission type="send" roles="guest"/>
+            <permission type="manage" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!-- if you define auto-create on certain queues, management has to be auto-create -->
+         <address-setting match="activemq.management#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+      </address-settings>
+
+      <addresses>
+         <address name="orders">
+            <multicast>
+            </multicast>
+         </address>
+      </addresses>
+
+   </core>
+</configuration>

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/spoke3/broker.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/src/main/resources/activemq/spoke3/broker.xml
@@ -1,0 +1,118 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:xi="http://www.w3.org/2001/XInclude"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="urn:activemq:core ">
+
+      <name>Spoke3</name>
+
+      <persistence-enabled>false</persistence-enabled>
+
+      <journal-type>NIO</journal-type>
+
+      <!-- should the broker detect dead locks and other issues -->
+      <critical-analyzer>true</critical-analyzer>
+
+      <critical-analyzer-timeout>120000</critical-analyzer-timeout>
+
+      <critical-analyzer-check-period>60000</critical-analyzer-check-period>
+
+      <critical-analyzer-policy>HALT</critical-analyzer-policy>
+
+      <page-sync-timeout>44000</page-sync-timeout>
+
+      <acceptors>
+         <!-- Acceptor for every supported protocol -->
+         <acceptor name="artemis">tcp://0.0.0.0:5860?tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;amqpMinLargeMessageSize=102400;protocols=CORE,AMQP,STOMP,HORNETQ,MQTT,OPENWIRE;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;amqpDuplicateDetection=true</acceptor>
+      </acceptors>
+
+      <broker-connections>
+         <amqp-connection uri="tcp://localhost:5460" name="federation-example-spoke-3" retry-interval="100">
+            <!-- This will create a federation connection between servers, the local
+                 server will federate messages sent to the address 'orders' from the
+                 remote and the remote will federate message sent to the address 'orders'
+                 on the local broker to itself. -->
+            <federation>
+               <local-address-policy name="address-federation-from-remote" max-hops="2">
+                  <include address-match="orders" />
+               </local-address-policy>
+               <remote-address-policy name="address-federation-to-remote" max-hops="2">
+                  <include address-match="orders" />
+               </remote-address-policy>
+             </federation>
+         </amqp-connection>
+      </broker-connections>
+
+      <security-settings>
+         <security-setting match="#">
+            <permission type="createNonDurableQueue" roles="guest"/>
+            <permission type="deleteNonDurableQueue" roles="guest"/>
+            <permission type="createDurableQueue" roles="guest"/>
+            <permission type="deleteDurableQueue" roles="guest"/>
+            <permission type="createAddress" roles="guest"/>
+            <permission type="deleteAddress" roles="guest"/>
+            <permission type="consume" roles="guest"/>
+            <permission type="browse" roles="guest"/>
+            <permission type="send" roles="guest"/>
+            <permission type="manage" roles="guest"/>
+         </security-setting>
+      </security-settings>
+
+      <address-settings>
+         <!-- if you define auto-create on certain queues, management has to be auto-create -->
+         <address-setting match="activemq.management#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+         <!--default for catch all-->
+         <address-setting match="#">
+            <dead-letter-address>DLQ</dead-letter-address>
+            <expiry-address>ExpiryQueue</expiry-address>
+            <redelivery-delay>0</redelivery-delay>
+            <!-- with -1 only the global-max-size is in use for limiting -->
+            <max-size-bytes>-1</max-size-bytes>
+            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+            <address-full-policy>PAGE</address-full-policy>
+            <auto-create-queues>true</auto-create-queues>
+            <auto-create-addresses>true</auto-create-addresses>
+         </address-setting>
+      </address-settings>
+
+      <addresses>
+         <address name="orders">
+            <multicast>
+            </multicast>
+         </address>
+      </addresses>
+
+   </core>
+</configuration>

--- a/examples/features/broker-connection/pom.xml
+++ b/examples/features/broker-connection/pom.xml
@@ -52,6 +52,7 @@ under the License.
             <module>amqp-receiving-messages</module>
             <module>amqp-sending-overssl</module>
             <module>amqp-federation</module>
+            <module>amqp-federation-multicast-hub-spoke</module>
             <module>disaster-recovery</module>
          </modules>
       </profile>
@@ -63,6 +64,7 @@ under the License.
             <module>amqp-receiving-messages</module>
             <module>amqp-sending-overssl</module>
             <module>amqp-federation</module>
+            <module>amqp-federation-multicast-hub-spoke</module>
             <module>disaster-recovery</module>
          </modules>
       </profile>

--- a/scripts/run-examples.sh
+++ b/scripts/run-examples.sh
@@ -174,4 +174,6 @@ cd amqp-receiving-messages; mvn verify; cd ..
 cd amqp-sending-messages; mvn verify; cd ..
 cd amqp-sending-overssl; mvn verify; cd ..
 cd disaster-recovery; mvn verify; cd ..
+cd amqp-federation; mvn verify; cd ..
+cd amqp-federation-multicast-hub-spoke; mvn verify; cd ..
 


### PR DESCRIPTION
Adds an example showing how AMQP federation can be used to federate multicast messages over a hub and spoke topology with bi-directional federation.

Also adds the AMQP federation examples to the run script