### PR TITLE
ARTEMIS-4802 - Fixing the use of depricating tags master,slave,check-…

### DIFF
--- a/examples/features/ha/replicated-failback/readme.md
+++ b/examples/features/ha/replicated-failback/readme.md
@@ -1,7 +1,15 @@
 # JMS Replicated Failback Example
 
-To run the example, simply type **mvn verify** from this directory.
+## Preparation
+If not already done, [Prepare the broker distribution](https://github.com/apache/activemq-artemis-examples?tab=readme-ov-file#prepare-the-broker-distribution).
+
+## Running the Example
+To run the example, simply execute the below command from this directory:
+```
+mvn verify
+```
 
 This example demonstrates two servers coupled as a live-backup pair for high availability (HA) using replication and a client connection failing over from live to backup when the live broker is crashed and then back to the original live when it is restarted (i.e. "failback").
 
 For more information on ActiveMQ Artemis failover and HA, and clustering in general, please see the clustering section of the user manual.
+

--- a/examples/features/ha/replicated-failback/src/main/resources/activemq/server0/broker.xml
+++ b/examples/features/ha/replicated-failback/src/main/resources/activemq/server0/broker.xml
@@ -34,10 +34,10 @@ under the License.
 
       <ha-policy>
          <replication>
-            <master>
+            <primary>
                <!--we need this for auto failback-->
-               <check-for-live-server>true</check-for-live-server>
-            </master>
+               <check-for-active-server>true</check-for-active-server>
+            </primary>
          </replication>
       </ha-policy>
 

--- a/examples/features/ha/replicated-failback/src/main/resources/activemq/server1/broker.xml
+++ b/examples/features/ha/replicated-failback/src/main/resources/activemq/server1/broker.xml
@@ -34,9 +34,9 @@ under the License.
 
       <ha-policy>
          <replication>
-            <slave>
+            <backup>
                <allow-failback>true</allow-failback>
-            </slave>
+            </backup>
          </replication>
       </ha-policy>
 


### PR DESCRIPTION
Fixing the use of deprecating tags master, slave, check-for-live-server in ha/replicated-failback sample with their new values
primary, backup and check-for-active-server 