### PR TITLE
ARTEMIS-5816: update groupId to org.apache.artemis for new TLP

### DIFF
--- a/artemis-distribution/pom.xml
+++ b/artemis-distribution/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>artemis-examples-build</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-distribution</artifactId>
@@ -48,7 +48,7 @@ under the License.
             <configuration>
                <artifactItems>
                   <artifactItem>
-                     <groupId>org.apache.activemq</groupId>
+                     <groupId>org.apache.artemis</groupId>
                      <artifactId>apache-artemis</artifactId>
                      <version>${project.version}</version>
                      <classifier>bin</classifier>

--- a/examples/features/broker-connection/amqp-bridge/pom.xml
+++ b/examples/features/broker-connection/amqp-bridge/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-bridge</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-bridge</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-multicast-fanout/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-fanout/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-multicast-fanout</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -342,7 +342,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-multicast-fanout</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-hub-spoke/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-multicast-hub-spoke</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -222,7 +222,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-multicast-hub-spoke</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-multicast-ring/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-multicast-ring/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-multicast-ring</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -222,7 +222,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-multicast-ring</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-over-ssl/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-over-ssl/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-over-ssl</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-over-ssl</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-queue-dual-federation/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-queue-dual-federation/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-queue-dual-federation</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-queue-dual-federation</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-queue-multiple-brokers/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-queue-multiple-brokers/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-queue-multiple-brokers</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -183,7 +183,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-queue-multiple-brokers</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-queue-priority/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-queue-priority/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-queue-priority</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-queue-priority</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation-queue-pull-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-federation-queue-pull-messages/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation-queue-pull-messages</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation-queue-pull-messages</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-federation/pom.xml
+++ b/examples/features/broker-connection/amqp-federation/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-federation</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-federation</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-receiving-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-receiving-messages/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-receiving-messages</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-receiving-messages</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-sending-messages-multicast/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-messages-multicast/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-sending-messages-multicast</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-sending-messages-multicast</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-sending-messages/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-messages/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-sending-messages</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-sending-messages</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/amqp-sending-overssl/pom.xml
+++ b/examples/features/broker-connection/amqp-sending-overssl/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>amqp-ssl-enabled</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>amqp-ssl-enabled</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/disaster-recovery/pom.xml
+++ b/examples/features/broker-connection/disaster-recovery/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker-connection</groupId>
+      <groupId>org.apache.artemis.examples.broker-connection</groupId>
       <artifactId>broker-connections</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>disaster-recovery</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker-connection</groupId>
+                  <groupId>org.apache.artemis.examples.broker-connection</groupId>
                   <artifactId>disaster-recovery</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/broker-connection/pom.xml
+++ b/examples/features/broker-connection/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.broker-connection</groupId>
+   <groupId>org.apache.artemis.examples.broker-connection</groupId>
    <artifactId>broker-connections</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Broker Connection Examples</name>

--- a/examples/features/clustered/client-side-load-balancing/pom.xml
+++ b/examples/features/clustered/client-side-load-balancing/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>client-side-load-balancing</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -194,7 +194,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>client-side-load-balancing</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-durable-subscription/pom.xml
+++ b/examples/features/clustered/clustered-durable-subscription/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-durable-subscription</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-durable-subscription</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-grouping/pom.xml
+++ b/examples/features/clustered/clustered-grouping/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-grouping</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-grouping</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-jgroups/pom.xml
+++ b/examples/features/clustered/clustered-jgroups/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-jgroups</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -138,7 +138,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-jgroups</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-queue/pom.xml
+++ b/examples/features/clustered/clustered-queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-queue</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -139,7 +139,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-static-discovery-uri/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery-uri/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-static-discovery-uri</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -220,7 +220,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-static-discovery-uri</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-static-discovery/pom.xml
+++ b/examples/features/clustered/clustered-static-discovery/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-static-discovery</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -220,7 +220,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-static-discovery</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-static-oneway/pom.xml
+++ b/examples/features/clustered/clustered-static-oneway/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-static-oneway</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -183,7 +183,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-static-oneway</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-topic-uri/pom.xml
+++ b/examples/features/clustered/clustered-topic-uri/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-topic-uri</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -139,7 +139,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-topic-uri</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/clustered-topic/pom.xml
+++ b/examples/features/clustered/clustered-topic/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-topic</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -139,7 +139,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>clustered-topic</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/pom.xml
+++ b/examples/features/clustered/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.clustered</groupId>
+   <groupId>org.apache.artemis.examples.clustered</groupId>
    <artifactId>broker-clustered</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Clustered Examples</name>

--- a/examples/features/clustered/queue-message-redistribution/pom.xml
+++ b/examples/features/clustered/queue-message-redistribution/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-message-redistribution</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -140,7 +140,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>queue-message-redistribution</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/shared-storage-static-cluster/pom.xml
+++ b/examples/features/clustered/shared-storage-static-cluster/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>shared-storage-static-cluster</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -133,7 +133,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>shared-storage-static-cluster</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/clustered/symmetric-cluster/pom.xml
+++ b/examples/features/clustered/symmetric-cluster/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-clustered</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>symmetric-cluster</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -289,7 +289,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.clustered</groupId>
+                  <groupId>org.apache.artemis.examples.clustered</groupId>
                   <artifactId>symmetric-cluster</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/connection-router/evenly-redirect/pom.xml
+++ b/examples/features/connection-router/evenly-redirect/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>evenly-redirect</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -184,7 +184,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples</groupId>
+                  <groupId>org.apache.artemis.examples</groupId>
                   <artifactId>evenly-redirect</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/connection-router/pom.xml
+++ b/examples/features/connection-router/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples</groupId>
+   <groupId>org.apache.artemis.examples</groupId>
    <artifactId>connection-router</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Connection Routers Examples</name>

--- a/examples/features/connection-router/symmetric-redirect/pom.xml
+++ b/examples/features/connection-router/symmetric-redirect/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>symmetric-redirect</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -145,7 +145,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples</groupId>
+                  <groupId>org.apache.artemis.examples</groupId>
                   <artifactId>symmetric-redirect</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/connection-router/symmetric-simple/pom.xml
+++ b/examples/features/connection-router/symmetric-simple/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>connection-router</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>symmetric-simple</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -140,7 +140,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples</groupId>
+                  <groupId>org.apache.artemis.examples</groupId>
                   <artifactId>symmetric-simple</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-address-divert/pom.xml
+++ b/examples/features/federation/federated-address-divert/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address-divert</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -139,7 +139,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-address-divert</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-address-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream-upstream/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address-downstream-upstream</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq.examples.federation</groupId>
+         <groupId>org.apache.artemis.examples.federation</groupId>
          <artifactId>federated-address</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-address-downstream-upstream</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-address-downstream/pom.xml
+++ b/examples/features/federation/federated-address-downstream/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address-downstream</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq.examples.federation</groupId>
+         <groupId>org.apache.artemis.examples.federation</groupId>
          <artifactId>federated-address</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-address-downstream</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-address/pom.xml
+++ b/examples/features/federation/federated-address/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-address</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-address</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-queue-downstream-upstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream-upstream/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-queue-downstream-upstream</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq.examples.federation</groupId>
+         <groupId>org.apache.artemis.examples.federation</groupId>
          <artifactId>federated-queue</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-queue-downstream-upstream</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-queue-downstream/pom.xml
+++ b/examples/features/federation/federated-queue-downstream/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-queue-downstream</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq.examples.federation</groupId>
+         <groupId>org.apache.artemis.examples.federation</groupId>
          <artifactId>federated-queue</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-queue-downstream</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/federated-queue/pom.xml
+++ b/examples/features/federation/federated-queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.federation</groupId>
+      <groupId>org.apache.artemis.examples.federation</groupId>
       <artifactId>broker-federation</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>federated-queue</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -178,7 +178,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.federation</groupId>
+                  <groupId>org.apache.artemis.examples.federation</groupId>
                   <artifactId>federated-queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/federation/pom.xml
+++ b/examples/features/federation/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.federation</groupId>
+   <groupId>org.apache.artemis.examples.federation</groupId>
    <artifactId>broker-federation</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Federation Examples</name>

--- a/examples/features/ha/application-layer-failover/pom.xml
+++ b/examples/features/ha/application-layer-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>application-layer-failover</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>application-layer-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/client-side-failoverlistener/pom.xml
+++ b/examples/features/ha/client-side-failoverlistener/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>client-side-failoverlistener</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -100,7 +100,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>client-side-failoverlistener</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/colocated-failover-scale-down/pom.xml
+++ b/examples/features/ha/colocated-failover-scale-down/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>colocated-failover-scale-down</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>colocated-failover-scale-down</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/colocated-failover/pom.xml
+++ b/examples/features/ha/colocated-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>colocated-failover</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>colocated-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/ha-policy-autobackup/pom.xml
+++ b/examples/features/ha/ha-policy-autobackup/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>ha-policy-autobackup</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>ha-policy-autobackup</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/multiple-failover-failback/pom.xml
+++ b/examples/features/ha/multiple-failover-failback/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>multiple-failover-failback</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -114,7 +114,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>multiple-failover-failback</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/multiple-failover/pom.xml
+++ b/examples/features/ha/multiple-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>multiple-failover</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -114,7 +114,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>multiple-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/non-transaction-failover/pom.xml
+++ b/examples/features/ha/non-transaction-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>non-transaction-failover</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -100,7 +100,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>non-transaction-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/pom.xml
+++ b/examples/features/ha/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.failover</groupId>
+   <groupId>org.apache.artemis.examples.failover</groupId>
    <artifactId>broker-failover</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Failover Examples</name>

--- a/examples/features/ha/replicated-failback-static/pom.xml
+++ b/examples/features/ha/replicated-failback-static/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-failback-static</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -96,7 +96,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>replicated-failback-static</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/replicated-failback/pom.xml
+++ b/examples/features/ha/replicated-failback/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-failback</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>replicated-failback</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/replicated-multiple-failover/pom.xml
+++ b/examples/features/ha/replicated-multiple-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-multiple-failover</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -109,7 +109,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>replicated-multiple-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/replicated-transaction-failover/pom.xml
+++ b/examples/features/ha/replicated-transaction-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>replicated-transaction-failover</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -92,7 +92,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>replicated-transaction-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/scale-down/pom.xml
+++ b/examples/features/ha/scale-down/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>scale-down</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -92,7 +92,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>scale-down</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/stop-server-failover/pom.xml
+++ b/examples/features/ha/stop-server-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stop-server-failover</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>stop-server-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/transaction-failover/pom.xml
+++ b/examples/features/ha/transaction-failover/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>transaction-failover</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -91,7 +91,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>transaction-failover</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/ha/zookeeper-single-pair-failback/pom.xml
+++ b/examples/features/ha/zookeeper-single-pair-failback/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.failover</groupId>
+      <groupId>org.apache.artemis.examples.failover</groupId>
       <artifactId>broker-failover</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>zookeeper-single-pair-failback</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.failover</groupId>
+                  <groupId>org.apache.artemis.examples.failover</groupId>
                   <artifactId>zookeeper-single-pair-failback</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/perf/perf/pom.xml
+++ b/examples/features/perf/perf/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.soak</groupId>
+      <groupId>org.apache.artemis.examples.soak</groupId>
       <artifactId>perf-root</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>openwire-perf</artifactId>
@@ -66,7 +66,7 @@ under the License.
       </dependency>
       <dependency>
          <!-- this is to have the ServerUtil -->
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -91,7 +91,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -119,7 +119,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.soak</groupId>
+                        <groupId>org.apache.artemis.examples.soak</groupId>
                         <artifactId>openwire-perf</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -133,7 +133,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -148,7 +148,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.soak</groupId>
+                        <groupId>org.apache.artemis.examples.soak</groupId>
                         <artifactId>openwire-perf</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -162,7 +162,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -177,7 +177,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.soak</groupId>
+                        <groupId>org.apache.artemis.examples.soak</groupId>
                         <artifactId>openwire-perf</artifactId>
                         <version>${project.version}</version>
                      </dependency>

--- a/examples/features/perf/pom.xml
+++ b/examples/features/perf/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.soak</groupId>
+   <groupId>org.apache.artemis.examples.soak</groupId>
    <artifactId>perf-root</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Performance Examples</name>

--- a/examples/features/perf/soak/pom.xml
+++ b/examples/features/perf/soak/pom.xml
@@ -26,14 +26,14 @@ under the License.
    <name>ActiveMQ Artemis Soak Normal Example</name>
 
    <parent>
-      <groupId>org.apache.activemq.examples.soak</groupId>
+      <groupId>org.apache.artemis.examples.soak</groupId>
       <artifactId>perf-root</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -59,7 +59,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -75,7 +75,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.soak</groupId>
+                        <groupId>org.apache.artemis.examples.soak</groupId>
                         <artifactId>artemis-jms-soak-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -89,7 +89,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -113,7 +113,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.soak</groupId>
+                        <groupId>org.apache.artemis.examples.soak</groupId>
                         <artifactId>artemis-jms-soak-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -127,7 +127,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -157,7 +157,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.soak</groupId>
+                        <groupId>org.apache.artemis.examples.soak</groupId>
                         <artifactId>artemis-jms-soak-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>

--- a/examples/features/pom.xml
+++ b/examples/features/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>artemis-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.clustered</groupId>
+   <groupId>org.apache.artemis.examples.clustered</groupId>
    <artifactId>broker-features</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Features Examples</name>

--- a/examples/features/standard/auto-closeable/pom.xml
+++ b/examples/features/standard/auto-closeable/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>auto-closeable</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -90,7 +90,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>auto-closeable</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/broker-msg-auth-plugin/pom.xml
+++ b/examples/features/standard/broker-msg-auth-plugin/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
     <artifactId>broker-msg-auth-plugin</artifactId>
@@ -37,17 +37,17 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -60,7 +60,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -68,7 +68,7 @@ under the License.
                   <phase>verify</phase>
                   <configuration>
                      <!-- The broker plugin will install this library on the server's classpath -->
-                     <libList><arg>org.apache.activemq.examples.broker:broker-msg-auth-plugin:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:broker-msg-auth-plugin:${project.version}</arg></libList>
                      <ignore>${noServer}</ignore>
                   </configuration>
                   <goals>
@@ -110,7 +110,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>broker-msg-auth-plugin</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/broker-plugin/pom.xml
+++ b/examples/features/standard/broker-plugin/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>broker-plugin</artifactId>
@@ -37,17 +37,17 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -60,7 +60,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -68,7 +68,7 @@ under the License.
                   <phase>verify</phase>
                   <configuration>
                      <!-- The broker plugin will install this library on the server's classpath -->
-                     <libList><arg>org.apache.activemq.examples.broker:broker-plugin:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:broker-plugin:${project.version}</arg></libList>
                      <ignore>${noServer}</ignore>
                   </configuration>
                   <goals>
@@ -110,7 +110,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>broker-plugin</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/browser/pom.xml
+++ b/examples/features/standard/browser/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>browser</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>browser</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/camel/camel-broker/pom.xml
+++ b/examples/features/standard/camel/camel-broker/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker.camel</groupId>
+      <groupId>org.apache.artemis.examples.broker.camel</groupId>
       <artifactId>camel</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>camel-broker</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq.examples.broker.camel</groupId>
+         <groupId>org.apache.artemis.examples.broker.camel</groupId>
          <artifactId>camel-war</artifactId>
          <version>${project.version}</version>
          <type>war</type>
@@ -56,7 +56,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <version>${project.version}</version>
             <executions>
@@ -69,7 +69,7 @@ under the License.
                      <webList>
                         <!-- pull in the war file from the camel-war maven module and put it into the "web" directory
                              so it will be deployed when the broker starts -->
-                        <arg>org.apache.activemq.examples.broker.camel:camel-war:war:${project.version}</arg>
+                        <arg>org.apache.artemis.examples.broker.camel:camel-war:war:${project.version}</arg>
                      </webList>
                      <replacePairs>
                            <arg>WARFILE</arg>
@@ -118,7 +118,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker.camel</groupId>
+                  <groupId>org.apache.artemis.examples.broker.camel</groupId>
                   <artifactId>camel-broker</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/camel/camel-war/pom.xml
+++ b/examples/features/standard/camel/camel-war/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker.camel</groupId>
+      <groupId>org.apache.artemis.examples.broker.camel</groupId>
       <artifactId>camel</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>camel-war</artifactId>

--- a/examples/features/standard/camel/pom.xml
+++ b/examples/features/standard/camel/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.broker.camel</groupId>
+   <groupId>org.apache.artemis.examples.broker.camel</groupId>
    <artifactId>camel</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Camel Example</name>

--- a/examples/features/standard/cdi/pom.xml
+++ b/examples/features/standard/cdi/pom.xml
@@ -22,9 +22,9 @@
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>cdi</artifactId>
@@ -51,17 +51,17 @@
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-commons</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -70,7 +70,7 @@
          <artifactId>jakarta.jms-api</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cdi-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -103,7 +103,7 @@
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -113,7 +113,7 @@
                         </goals>
                         <configuration>
                            <libListWithDeps>
-                              <arg>org.apache.activemq.examples.broker:cdi:${project.version}</arg>
+                              <arg>org.apache.artemis.examples.broker:cdi:${project.version}</arg>
                            </libListWithDeps>
                            <instance>${basedir}/target/server0</instance>
                            <configuration>${basedir}/target/classes/activemq/server0</configuration>
@@ -156,7 +156,7 @@
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.broker</groupId>
+                        <groupId>org.apache.artemis.examples.broker</groupId>
                         <artifactId>cdi</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -180,7 +180,7 @@
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -190,7 +190,7 @@
                         </goals>
                         <configuration>
                            <libListWithDeps>
-                              <arg>org.apache.activemq.examples.broker:cdi:${project.version}</arg>
+                              <arg>org.apache.artemis.examples.broker:cdi:${project.version}</arg>
                            </libListWithDeps>
 
                            <instance>${basedir}/target/server0</instance>
@@ -225,7 +225,7 @@
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.broker</groupId>
+                        <groupId>org.apache.artemis.examples.broker</groupId>
                         <artifactId>cdi</artifactId>
                         <version>${project.version}</version>
                      </dependency>

--- a/examples/features/standard/client-kickoff/pom.xml
+++ b/examples/features/standard/client-kickoff/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>client-kickoff</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>client-kickoff</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/completion-listener/pom.xml
+++ b/examples/features/standard/completion-listener/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>completion-listener</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>completion-listener</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/consumer-rate-limit/pom.xml
+++ b/examples/features/standard/consumer-rate-limit/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>consumer-rate-limit</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>consumer-rate-limit</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/context/pom.xml
+++ b/examples/features/standard/context/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>context</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>context</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/core-bridge/pom.xml
+++ b/examples/features/standard/core-bridge/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>core-bridge</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -61,7 +61,7 @@ under the License.
                   <configuration>
                      <libList>
                         <!-- For the transformer -->
-                        <arg>org.apache.activemq.examples.broker:core-bridge:${project.version}</arg>
+                        <arg>org.apache.artemis.examples.broker:core-bridge:${project.version}</arg>
                      </libList>
                      <ignore>${noServer}</ignore>
                      <instance>${basedir}/target/server0</instance>
@@ -76,7 +76,7 @@ under the License.
                   <configuration>
                      <libList>
                         <!-- For the transformer -->
-                        <arg>org.apache.activemq.examples.broker:core-bridge:${project.version}</arg>
+                        <arg>org.apache.artemis.examples.broker:core-bridge:${project.version}</arg>
                      </libList>
                      <ignore>${noServer}</ignore>
                      <instance>${basedir}/target/server1</instance>
@@ -148,7 +148,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>core-bridge</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/database/pom.xml
+++ b/examples/features/standard/database/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>database</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -102,7 +102,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>database</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/dead-letter/pom.xml
+++ b/examples/features/standard/dead-letter/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>dead-letter</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>dead-letter</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/delayed-redelivery/pom.xml
+++ b/examples/features/standard/delayed-redelivery/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>delayed-redelivery</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>delayed-redelivery</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/divert/pom.xml
+++ b/examples/features/standard/divert/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
    <artifactId>divert</artifactId>
    <packaging>jar</packaging>
@@ -36,12 +36,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -60,7 +60,7 @@ under the License.
                   </goals>
                   <configuration>
                      <ignore>${noServer}</ignore>
-                     <libList><arg>org.apache.activemq.examples.broker:divert:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:divert:${project.version}</arg></libList>
                      <instance>${basedir}/target/server0</instance>
                      <configuration>${basedir}/target/classes/activemq/server0</configuration>
                   </configuration>
@@ -72,7 +72,7 @@ under the License.
                   </goals>
                   <configuration>
                      <ignore>${noServer}</ignore>
-                     <libList><arg>org.apache.activemq.examples.broker:divert:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:divert:${project.version}</arg></libList>
                      <instance>${basedir}/target/server1</instance>
                      <configuration>${basedir}/target/classes/activemq/server1</configuration>
                   </configuration>
@@ -140,7 +140,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>divert</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/durable-subscription/pom.xml
+++ b/examples/features/standard/durable-subscription/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>durable-subscription</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>durable-subscription</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/embedded-simple/pom.xml
+++ b/examples/features/standard/embedded-simple/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>embedded-simple</artifactId>
@@ -37,17 +37,17 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -56,7 +56,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -71,7 +71,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>embedded-simple</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/embedded/pom.xml
+++ b/examples/features/standard/embedded/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>embedded</artifactId>
@@ -37,17 +37,17 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -56,7 +56,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -71,7 +71,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>embedded</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/exclusive-queue/pom.xml
+++ b/examples/features/standard/exclusive-queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>exclusive-queue</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -103,7 +103,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>exclusive-queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/expiry/pom.xml
+++ b/examples/features/standard/expiry/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>expiry</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>expiry</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/http-transport/pom.xml
+++ b/examples/features/standard/http-transport/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>http-transport</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>http-transport</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/instantiate-connection-factory/pom.xml
+++ b/examples/features/standard/instantiate-connection-factory/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>instantiate-connection-factory</artifactId>
@@ -38,7 +38,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -47,7 +47,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>instantiate-connection-factory</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/interceptor-amqp/pom.xml
+++ b/examples/features/standard/interceptor-amqp/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor-amqp</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -60,7 +60,7 @@ under the License.
                      <goal>create</goal>
                   </goals>
                   <configuration>
-                     <libList><arg>org.apache.activemq.examples.broker:interceptor-amqp:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:interceptor-amqp:${project.version}</arg></libList>
                      <ignore>${noServer}</ignore>
                      <configuration>${basedir}/target/classes/activemq/server0</configuration>
                   </configuration>
@@ -100,7 +100,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>interceptor-amqp</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/interceptor-client/pom.xml
+++ b/examples/features/standard/interceptor-client/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor-client</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>interceptor-client</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/interceptor-mqtt/pom.xml
+++ b/examples/features/standard/interceptor-mqtt/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor-mqtt</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-mqtt-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -60,7 +60,7 @@ under the License.
                      <goal>create</goal>
                   </goals>
                   <configuration>
-                     <libList><arg>org.apache.activemq.examples.broker:interceptor-mqtt:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:interceptor-mqtt:${project.version}</arg></libList>
                      <ignore>${noServer}</ignore>
                      <configuration>${basedir}/target/classes/activemq/server0</configuration>
                   </configuration>
@@ -100,7 +100,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>interceptor-mqtt</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/interceptor/pom.xml
+++ b/examples/features/standard/interceptor/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>interceptor</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -55,7 +55,7 @@ under the License.
                      <goal>create</goal>
                   </goals>
                   <configuration>
-                     <libList><arg>org.apache.activemq.examples.broker:interceptor:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.broker:interceptor:${project.version}</arg></libList>
                      <ignore>${noServer}</ignore>
                      <configuration>${basedir}/target/classes/activemq/server0</configuration>
                   </configuration>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>interceptor</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/jms-bridge/pom.xml
+++ b/examples/features/standard/jms-bridge/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>jms-bridge</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -140,7 +140,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>jms-bridge</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/jmx-ssl/pom.xml
+++ b/examples/features/standard/jmx-ssl/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>jmx-ssl</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -102,7 +102,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>jmx-ssl</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/jmx/pom.xml
+++ b/examples/features/standard/jmx/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>jmx</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -99,7 +99,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>jmx</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/large-message/pom.xml
+++ b/examples/features/standard/large-message/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>large-message</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -76,7 +76,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>large-message</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/last-value-queue/pom.xml
+++ b/examples/features/standard/last-value-queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>last-value-queue</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>last-value-queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/management-notifications/pom.xml
+++ b/examples/features/standard/management-notifications/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>management-notifications</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>management-notifications</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/management/pom.xml
+++ b/examples/features/standard/management/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>management</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>management</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/message-counters/pom.xml
+++ b/examples/features/standard/message-counters/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-counters</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -99,7 +99,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>message-counters</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/message-group/pom.xml
+++ b/examples/features/standard/message-group/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-group</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>message-group</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/message-group2/pom.xml
+++ b/examples/features/standard/message-group2/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-group2</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>message-group2</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/message-priority/pom.xml
+++ b/examples/features/standard/message-priority/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-priority</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>message-priority</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/netty-openssl/pom.xml
+++ b/examples/features/standard/netty-openssl/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>netty-openssl</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -52,7 +52,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -100,7 +100,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>netty-openssl</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/no-consumer-buffering/pom.xml
+++ b/examples/features/standard/no-consumer-buffering/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>no-consumer-buffering</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>no-consumer-buffering</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/opentelemetry/pom.xml
+++ b/examples/features/standard/opentelemetry/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>opentelemetry</artifactId>
@@ -38,17 +38,17 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-amqp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -118,7 +118,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -127,7 +127,7 @@ under the License.
                   <configuration>
                      <!-- The broker plugin will install this library on the server's classpath -->
                      <libList>
-                        <arg>org.apache.activemq.examples.broker:opentelemetry:${project.version}</arg>
+                        <arg>org.apache.artemis.examples.broker:opentelemetry:${project.version}</arg>
                      </libList>
                      <libListWithDeps>
                         <arg>io.opentelemetry:opentelemetry-api:${opentelemetry.version}</arg>
@@ -181,7 +181,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>opentelemetry</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/paging/pom.xml
+++ b/examples/features/standard/paging/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>paging</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>paging</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/pom.xml
+++ b/examples/features/standard/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.broker</groupId>
+   <groupId>org.apache.artemis.examples.broker</groupId>
    <artifactId>jms-examples</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Standard Examples</name>

--- a/examples/features/standard/pre-acknowledge/pom.xml
+++ b/examples/features/standard/pre-acknowledge/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>pre-acknowledge</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>pre-acknowledge</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/producer-rate-limit/pom.xml
+++ b/examples/features/standard/producer-rate-limit/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>producer-rate-limit</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>producer-rate-limit</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/queue-jakarta/pom.xml
+++ b/examples/features/standard/queue-jakarta/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-jakarta</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jakarta-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -57,8 +57,8 @@ under the License.
                   </goals>
                   <configuration>
                      <libList>
-                        <arg>org.apache.activemq:artemis-jakarta-client-all:${project.version}</arg>
-                        <arg>org.apache.activemq.examples.broker:queue-jakarta:${project.version}</arg>
+                        <arg>org.apache.artemis:artemis-jakarta-client-all:${project.version}</arg>
+                        <arg>org.apache.artemis.examples.broker:queue-jakarta:${project.version}</arg>
                      </libList>
                      <variableName>ARTEMIS-JAKARTA</variableName>
                   </configuration>
@@ -108,7 +108,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>queue-jakarta</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/queue-requestor/pom.xml
+++ b/examples/features/standard/queue-requestor/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-requestor</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -88,7 +88,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>queue-requestor</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/queue-selector/pom.xml
+++ b/examples/features/standard/queue-selector/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-selector</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>queue-selector</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/queue/pom.xml
+++ b/examples/features/standard/queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/reattach-node/pom.xml
+++ b/examples/features/standard/reattach-node/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>reattach-node</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>reattach-node</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/request-reply/pom.xml
+++ b/examples/features/standard/request-reply/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>request-reply</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -97,7 +97,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>request-reply</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/scheduled-message/pom.xml
+++ b/examples/features/standard/scheduled-message/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>scheduled-message</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -98,7 +98,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>scheduled-message</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/security-keycloak/pom.xml
+++ b/examples/features/standard/security-keycloak/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>security-keycloak</artifactId>
@@ -40,7 +40,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -69,7 +69,7 @@ under the License.
             </executions>
          </plugin>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -127,7 +127,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>security-keycloak</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/security-ldap/pom.xml
+++ b/examples/features/standard/security-ldap/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>security-ldap</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -86,7 +86,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -135,7 +135,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>security-ldap</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/security-manager/pom.xml
+++ b/examples/features/standard/security-manager/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>security-manager</artifactId>
@@ -37,12 +37,12 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
          <scope>compile</scope>
@@ -52,7 +52,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -63,7 +63,7 @@ under the License.
                   <configuration>
                      <libList>
                         <!-- For the security manager -->
-                        <arg>org.apache.activemq.examples.broker:security-manager:${project.version}</arg>
+                        <arg>org.apache.artemis.examples.broker:security-manager:${project.version}</arg>
                      </libList>
                      <ignore>${noServer}</ignore>
                      <allowAnonymous>false</allowAnonymous>
@@ -106,7 +106,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>security-manager</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/security/pom.xml
+++ b/examples/features/standard/security/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>security</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -96,7 +96,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>security</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/send-acknowledgements/pom.xml
+++ b/examples/features/standard/send-acknowledgements/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>send-acknowledgements</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -88,7 +88,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>send-acknowledgements</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/shared-consumer/pom.xml
+++ b/examples/features/standard/shared-consumer/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>shared-consumer</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>shared-consumer</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/slow-consumer/pom.xml
+++ b/examples/features/standard/slow-consumer/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>slow-consumer</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -102,7 +102,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>slow-consumer</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/spring-boot-integration/pom.xml
+++ b/examples/features/standard/spring-boot-integration/pom.xml
@@ -16,9 +16,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>org.apache.activemq.examples.broker</groupId>
+		<groupId>org.apache.artemis.examples.broker</groupId>
 		<artifactId>jms-examples</artifactId>
-		<version>2.45.0-SNAPSHOT</version>
+		<version>2.50.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-boot-integration</artifactId>
 	<name>ActiveMQ Artemis JMS Spring Boot Integration Example</name>
@@ -33,7 +33,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.apache.activemq</groupId>
+			<groupId>org.apache.artemis</groupId>
 			<artifactId>artemis-amqp-protocol</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -46,7 +46,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.activemq</groupId>
+				<groupId>org.apache.artemis</groupId>
 				<artifactId>artemis-maven-plugin</artifactId>
 				<executions>
 					<execution>
@@ -61,7 +61,7 @@
 				</executions>
 				<dependencies>
 					<dependency>
-						<groupId>org.apache.activemq.examples.broker</groupId>
+						<groupId>org.apache.artemis.examples.broker</groupId>
 						<artifactId>spring-boot-integration</artifactId>
 						<version>${project.version}</version>
 					</dependency>

--- a/examples/features/standard/spring-integration/pom.xml
+++ b/examples/features/standard/spring-integration/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>spring-integration</artifactId>
@@ -37,11 +37,11 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
       </dependency>
       <dependency>
@@ -61,7 +61,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -76,7 +76,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>spring-integration</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/ssl-enabled-crl-mqtt/pom.xml
+++ b/examples/features/standard/ssl-enabled-crl-mqtt/pom.xml
@@ -22,9 +22,9 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.activemq.examples.broker</groupId>
+        <groupId>org.apache.artemis.examples.broker</groupId>
         <artifactId>jms-examples</artifactId>
-        <version>2.45.0-SNAPSHOT</version>
+        <version>2.50.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ssl-enabled-crl-mqtt</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jms-client-all</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -50,7 +50,7 @@ under the License.
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-maven-plugin</artifactId>
                 <executions>
                     <execution>
@@ -99,7 +99,7 @@ under the License.
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.apache.activemq.examples.broker</groupId>
+                        <groupId>org.apache.artemis.examples.broker</groupId>
                         <artifactId>ssl-enabled-crl-mqtt</artifactId>
                         <version>${project.version}</version>
                     </dependency>

--- a/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
+++ b/examples/features/standard/ssl-enabled-dual-authentication/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>ssl-enabled-dual-authentication</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -95,7 +95,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>ssl-enabled-dual-authentication</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/ssl-enabled/pom.xml
+++ b/examples/features/standard/ssl-enabled/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>ssl-enabled</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>ssl-enabled</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/static-selector/pom.xml
+++ b/examples/features/standard/static-selector/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>static-selector</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>static-selector</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/temp-queue/pom.xml
+++ b/examples/features/standard/temp-queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>temp-queue</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>temp-queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/topic-hierarchies/pom.xml
+++ b/examples/features/standard/topic-hierarchies/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic-hierarchies</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -97,7 +97,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>topic-hierarchies</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/topic-selector1/pom.xml
+++ b/examples/features/standard/topic-selector1/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic-selector1</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>topic-selector1</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/topic-selector2/pom.xml
+++ b/examples/features/standard/topic-selector2/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic-selector2</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>topic-selector2</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/topic/pom.xml
+++ b/examples/features/standard/topic/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>topic</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>topic</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/transactional/pom.xml
+++ b/examples/features/standard/transactional/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>transactional</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>transactional</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/xa-heuristic/pom.xml
+++ b/examples/features/standard/xa-heuristic/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>xa-heuristic</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -94,7 +94,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>xa-heuristic</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/xa-receive/pom.xml
+++ b/examples/features/standard/xa-receive/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>xa-receive</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>xa-receive</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/standard/xa-send/pom.xml
+++ b/examples/features/standard/xa-send/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.broker</groupId>
+      <groupId>org.apache.artemis.examples.broker</groupId>
       <artifactId>jms-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>xa-send</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client-all</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.broker</groupId>
+                  <groupId>org.apache.artemis.examples.broker</groupId>
                   <artifactId>xa-send</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/features/sub-modules/artemis-jakarta-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-jakarta-ra-rar/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.modules</groupId>
+      <groupId>org.apache.artemis.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jakarta-rar</artifactId>
@@ -37,16 +37,16 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jakarta-client</artifactId>
          <version>${project.version}</version>
          <exclusions>
             <exclusion>
-               <groupId>org.apache.activemq</groupId>
+               <groupId>org.apache.artemis</groupId>
                <artifactId>artemis-core-client</artifactId>
             </exclusion>
             <exclusion>
-               <groupId>org.apache.activemq</groupId>
+               <groupId>org.apache.artemis</groupId>
                <artifactId>artemis-jakarta-client</artifactId>
             </exclusion>
             <exclusion>
@@ -64,7 +64,7 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jakarta-ra</artifactId>
          <version>${project.version}</version>
          <exclusions>
@@ -79,7 +79,7 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jakarta-server</artifactId>
          <version>${project.version}</version>
          <exclusions>
@@ -98,12 +98,12 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
          <exclusions>
             <exclusion>
-               <groupId>org.apache.activemq</groupId>
+               <groupId>org.apache.artemis</groupId>
                <artifactId>artemis-core-client</artifactId>
             </exclusion>
             <exclusion>

--- a/examples/features/sub-modules/artemis-ra-rar/pom.xml
+++ b/examples/features/sub-modules/artemis-ra-rar/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.modules</groupId>
+      <groupId>org.apache.artemis.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-rar</artifactId>
@@ -37,16 +37,16 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
          <exclusions>
             <exclusion>
-               <groupId>org.apache.activemq</groupId>
+               <groupId>org.apache.artemis</groupId>
                <artifactId>artemis-core-client</artifactId>
             </exclusion>
             <exclusion>
-               <groupId>org.apache.activemq</groupId>
+               <groupId>org.apache.artemis</groupId>
                <artifactId>artemis-jms-client</artifactId>
             </exclusion>
             <exclusion>
@@ -64,7 +64,7 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-ra</artifactId>
          <version>${project.version}</version>
          <exclusions>
@@ -79,7 +79,7 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
          <exclusions>
@@ -98,12 +98,12 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-core-client</artifactId>
          <version>${project.version}</version>
          <exclusions>
             <exclusion>
-               <groupId>org.apache.activemq</groupId>
+               <groupId>org.apache.artemis</groupId>
                <artifactId>artemis-core-client</artifactId>
             </exclusion>
             <exclusion>

--- a/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/artemis-jms-bridge/pom.xml
@@ -23,9 +23,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.modules</groupId>
+      <groupId>org.apache.artemis.examples.modules</groupId>
       <artifactId>inter-broker-bridge-pom</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-jms-bridge</artifactId>
@@ -66,19 +66,19 @@ under the License.
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
          <scope>provided</scope>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
          <scope>provided</scope>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
          <scope>provided</scope>

--- a/examples/features/sub-modules/inter-broker-bridge/pom.xml
+++ b/examples/features/sub-modules/inter-broker-bridge/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.modules</groupId>
+      <groupId>org.apache.artemis.examples.modules</groupId>
       <artifactId>broker-modules</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.modules</groupId>
+   <groupId>org.apache.artemis.examples.modules</groupId>
    <artifactId>inter-broker-bridge-pom</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Inter-broker Bridging Examples</name>

--- a/examples/features/sub-modules/pom.xml
+++ b/examples/features/sub-modules/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.clustered</groupId>
+      <groupId>org.apache.artemis.examples.clustered</groupId>
       <artifactId>broker-features</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.modules</groupId>
+   <groupId>org.apache.artemis.examples.modules</groupId>
    <artifactId>broker-modules</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Modules Examples</name>

--- a/examples/features/sub-modules/tomcat/pom.xml
+++ b/examples/features/sub-modules/tomcat/pom.xml
@@ -21,9 +21,9 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.activemq.examples.modules</groupId>
+        <groupId>org.apache.artemis.examples.modules</groupId>
         <artifactId>broker-modules</artifactId>
-        <version>2.45.0-SNAPSHOT</version>
+        <version>2.50.0-SNAPSHOT</version>
     </parent>
 
 
@@ -57,7 +57,7 @@ under the License.
         </dependency>
         
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jms-client</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -84,7 +84,7 @@ under the License.
                             <warRunDependencies>
                                 <warRunDependency>
                                     <dependency>
-                                        <groupId>org.apache.activemq.examples.modules</groupId>
+                                        <groupId>org.apache.artemis.examples.modules</groupId>
                                         <artifactId>artemis-tomcat-jndi-resources-sample</artifactId>
                                         <version>${project.version}</version>
                                         <type>war</type>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>artemis-examples-build</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>artemis-examples</artifactId>

--- a/examples/protocols/amqp/pom.xml
+++ b/examples/protocols/amqp/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.protocols</groupId>
+      <groupId>org.apache.artemis.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.amqp</groupId>
+   <groupId>org.apache.artemis.examples.amqp</groupId>
    <artifactId>amqp</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis amqp Examples</name>

--- a/examples/protocols/amqp/proton-clustered-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-clustered-cpp/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.amqp</groupId>
+      <groupId>org.apache.artemis.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>proton-clustered-cpp</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -54,7 +54,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -147,7 +147,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.amqp</groupId>
+                  <groupId>org.apache.artemis.examples.amqp</groupId>
                   <artifactId>protoncpp</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/amqp/proton-cpp/pom.xml
+++ b/examples/protocols/amqp/proton-cpp/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.amqp</groupId>
+      <groupId>org.apache.artemis.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>protoncpp</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -54,7 +54,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -101,7 +101,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.amqp</groupId>
+                  <groupId>org.apache.artemis.examples.amqp</groupId>
                   <artifactId>protoncpp</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/amqp/proton-ruby/pom.xml
+++ b/examples/protocols/amqp/proton-ruby/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.amqp</groupId>
+      <groupId>org.apache.artemis.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>proton-ruby</artifactId>
@@ -38,7 +38,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -54,7 +54,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.amqp</groupId>
+                  <groupId>org.apache.artemis.examples.amqp</groupId>
                   <artifactId>proton-ruby</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/amqp/queue/pom.xml
+++ b/examples/protocols/amqp/queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.amqp</groupId>
+      <groupId>org.apache.artemis.examples.amqp</groupId>
       <artifactId>amqp</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -92,7 +92,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.amqp</groupId>
+                  <groupId>org.apache.artemis.examples.amqp</groupId>
                   <artifactId>queue</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/amqp/sasl-scram/pom.xml
+++ b/examples/protocols/amqp/sasl-scram/pom.xml
@@ -22,9 +22,9 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.apache.activemq.examples.amqp</groupId>
+        <groupId>org.apache.artemis.examples.amqp</groupId>
         <artifactId>amqp</artifactId>
-        <version>2.45.0-SNAPSHOT</version>
+        <version>2.50.0-SNAPSHOT</version>
     </parent>
     <properties>
         <activemq.basedir>${project.basedir}/../../../..</activemq.basedir>
@@ -44,7 +44,7 @@ under the License.
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.activemq</groupId>
+                <groupId>org.apache.artemis</groupId>
                 <artifactId>artemis-maven-plugin</artifactId>
                 <executions>
                     <execution>
@@ -95,7 +95,7 @@ under the License.
                 </executions>
                 <dependencies>
                     <dependency>
-                        <groupId>org.apache.activemq.examples.amqp</groupId>
+                        <groupId>org.apache.artemis.examples.amqp</groupId>
                         <artifactId>sasl-scram</artifactId>
                         <version>${project.version}</version>
                     </dependency>

--- a/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
+++ b/examples/protocols/mqtt/clustered-queue-mqtt/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.mqtt</groupId>
+      <groupId>org.apache.artemis.examples.mqtt</groupId>
       <artifactId>mqtt-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>clustered-queue-mqtt</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -50,7 +50,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -143,7 +143,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.mqtt</groupId>
+                  <groupId>org.apache.artemis.examples.mqtt</groupId>
                   <artifactId>clustered-queue-mqtt</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/mqtt/pom.xml
+++ b/examples/protocols/mqtt/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.protocols</groupId>
+      <groupId>org.apache.artemis.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.mqtt</groupId>
+   <groupId>org.apache.artemis.examples.mqtt</groupId>
    <artifactId>mqtt-examples</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis MQTT Examples</name>

--- a/examples/protocols/mqtt/publish-subscribe/pom.xml
+++ b/examples/protocols/mqtt/publish-subscribe/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.mqtt</groupId>
+      <groupId>org.apache.artemis.examples.mqtt</groupId>
       <artifactId>mqtt-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>publish-subscribe</artifactId>
@@ -45,7 +45,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -89,7 +89,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.mqtt</groupId>
+                  <groupId>org.apache.artemis.examples.mqtt</groupId>
                   <artifactId>publish-subscribe</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/openwire/chat/pom.xml
+++ b/examples/protocols/openwire/chat/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.openwire</groupId>
+      <groupId>org.apache.artemis.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>chat-example</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -86,7 +86,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -110,7 +110,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.openwire</groupId>
+                        <groupId>org.apache.artemis.examples.openwire</groupId>
                         <artifactId>chat-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -124,7 +124,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -143,7 +143,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.openwire</groupId>
+                        <groupId>org.apache.artemis.examples.openwire</groupId>
                         <artifactId>chat-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -157,7 +157,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -176,7 +176,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.openwire</groupId>
+                        <groupId>org.apache.artemis.examples.openwire</groupId>
                         <artifactId>chat-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>
@@ -190,7 +190,7 @@ under the License.
          <build>
             <plugins>
                <plugin>
-                  <groupId>org.apache.activemq</groupId>
+                  <groupId>org.apache.artemis</groupId>
                   <artifactId>artemis-maven-plugin</artifactId>
                   <executions>
                      <execution>
@@ -209,7 +209,7 @@ under the License.
                   </executions>
                   <dependencies>
                      <dependency>
-                        <groupId>org.apache.activemq.examples.openwire</groupId>
+                        <groupId>org.apache.artemis.examples.openwire</groupId>
                         <artifactId>chat-example</artifactId>
                         <version>${project.version}</version>
                      </dependency>

--- a/examples/protocols/openwire/message-listener/pom.xml
+++ b/examples/protocols/openwire/message-listener/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.openwire</groupId>
+      <groupId>org.apache.artemis.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-listener</artifactId>
@@ -69,7 +69,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -113,7 +113,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.openwire</groupId>
+                  <groupId>org.apache.artemis.examples.openwire</groupId>
                   <artifactId>message-listener</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/openwire/message-recovery/pom.xml
+++ b/examples/protocols/openwire/message-recovery/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.openwire</groupId>
+      <groupId>org.apache.artemis.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>message-recovery</artifactId>
@@ -66,7 +66,7 @@ under the License.
       </dependency>
       <dependency>
          <!-- this is to have the ServerUtil -->
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-cli</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -75,7 +75,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -102,7 +102,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.openwire</groupId>
+                  <groupId>org.apache.artemis.examples.openwire</groupId>
                   <artifactId>message-recovery</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/openwire/pom.xml
+++ b/examples/protocols/openwire/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.protocols</groupId>
+      <groupId>org.apache.artemis.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.openwire</groupId>
+   <groupId>org.apache.artemis.examples.openwire</groupId>
    <artifactId>openwire-examples</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Openwire Examples</name>

--- a/examples/protocols/openwire/queue/pom.xml
+++ b/examples/protocols/openwire/queue/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.openwire</groupId>
+      <groupId>org.apache.artemis.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>queue-openwire</artifactId>
@@ -69,7 +69,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -116,7 +116,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.openwire</groupId>
+                  <groupId>org.apache.artemis.examples.openwire</groupId>
                   <artifactId>queue-openwire</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/openwire/virtual-topic-mapping/pom.xml
+++ b/examples/protocols/openwire/virtual-topic-mapping/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.openwire</groupId>
+      <groupId>org.apache.artemis.examples.openwire</groupId>
       <artifactId>openwire-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>virtual-topic-mapping</artifactId>
@@ -69,7 +69,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -116,7 +116,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.openwire</groupId>
+                  <groupId>org.apache.artemis.examples.openwire</groupId>
                   <artifactId>virtual-topic-mapping</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/pom.xml
+++ b/examples/protocols/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples</groupId>
+      <groupId>org.apache.artemis.examples</groupId>
       <artifactId>artemis-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.protocols</groupId>
+   <groupId>org.apache.artemis.examples.protocols</groupId>
    <artifactId>protocols</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis Protocols Root Example</name>

--- a/examples/protocols/stomp/pom.xml
+++ b/examples/protocols/stomp/pom.xml
@@ -22,12 +22,12 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.protocols</groupId>
+      <groupId>org.apache.artemis.examples.protocols</groupId>
       <artifactId>protocols</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples.stomp</groupId>
+   <groupId>org.apache.artemis.examples.stomp</groupId>
    <artifactId>stomp-examples</artifactId>
    <packaging>pom</packaging>
    <name>ActiveMQ Artemis stomp Examples</name>

--- a/examples/protocols/stomp/stomp-dual-authentication/pom.xml
+++ b/examples/protocols/stomp/stomp-dual-authentication/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-dual-authentication</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -98,7 +98,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp-dual-authentication</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
+++ b/examples/protocols/stomp/stomp-embedded-interceptor/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-embedded-interceptor</artifactId>
@@ -37,22 +37,22 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-server</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-stomp-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-hornetq-protocol</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -61,7 +61,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -71,7 +71,7 @@ under the License.
                   </goals>
                   <configuration>
                      <!-- need to install the jar for interceptors on the server -->
-                     <libList><arg>org.apache.activemq.examples.stomp:stomp-embedded-interceptor:${project.version}</arg></libList>
+                     <libList><arg>org.apache.artemis.examples.stomp:stomp-embedded-interceptor:${project.version}</arg></libList>
                      <ignore>${noServer}</ignore>
                      <configuration>${basedir}/target/classes/activemq/server0</configuration>
                   </configuration>
@@ -111,7 +111,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp-embedded-interceptor</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/stomp/stomp-jms/pom.xml
+++ b/examples/protocols/stomp/stomp-jms/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-jms</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -51,7 +51,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -98,7 +98,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp-jms</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/stomp/stomp-websockets/pom.xml
+++ b/examples/protocols/stomp/stomp-websockets/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp-websockets</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp-websockets</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/stomp/stomp/pom.xml
+++ b/examples/protocols/stomp/stomp/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/stomp/stomp1.1/pom.xml
+++ b/examples/protocols/stomp/stomp1.1/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp1.1</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp1.1</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/examples/protocols/stomp/stomp1.2/pom.xml
+++ b/examples/protocols/stomp/stomp1.2/pom.xml
@@ -22,9 +22,9 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq.examples.stomp</groupId>
+      <groupId>org.apache.artemis.examples.stomp</groupId>
       <artifactId>stomp-examples</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
    <artifactId>stomp1.2</artifactId>
@@ -37,7 +37,7 @@ under the License.
 
    <dependencies>
       <dependency>
-         <groupId>org.apache.activemq</groupId>
+         <groupId>org.apache.artemis</groupId>
          <artifactId>artemis-jms-client</artifactId>
          <version>${project.version}</version>
       </dependency>
@@ -46,7 +46,7 @@ under the License.
    <build>
       <plugins>
          <plugin>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-maven-plugin</artifactId>
             <executions>
                <execution>
@@ -93,7 +93,7 @@ under the License.
             </executions>
             <dependencies>
                <dependency>
-                  <groupId>org.apache.activemq.examples.stomp</groupId>
+                  <groupId>org.apache.artemis.examples.stomp</groupId>
                   <artifactId>stomp1.2</artifactId>
                   <version>${project.version}</version>
                </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,15 +22,14 @@ under the License.
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
-      <groupId>org.apache.activemq</groupId>
+      <groupId>org.apache.artemis</groupId>
       <artifactId>artemis-pom</artifactId>
-      <version>2.45.0-SNAPSHOT</version>
-      <relativePath>org.apache.activemq:artemis-pom</relativePath>
+      <version>2.50.0-SNAPSHOT</version>
    </parent>
 
-   <groupId>org.apache.activemq.examples</groupId>
+   <groupId>org.apache.artemis.examples</groupId>
    <artifactId>artemis-examples-build</artifactId>
-   <version>2.45.0-SNAPSHOT</version>
+   <version>2.50.0-SNAPSHOT</version>
    <packaging>pom</packaging>
    <name>Apache Artemis Examples Build</name>
 


### PR DESCRIPTION
Update examples + dependencies groupId to `org.apache.artemis` for the new TLP.  Also bumps version to 2.50.0-SNAPSHOT as related change in main build does (will reference after opening its PR, want it to mention this one).

The CI will fail on this run since the matching changes in the artemis repo havent been merged yet. However I have run these changes against the Artemis changes via a manual CI execution (which lets you specify the Artemis repo + branch to use) in my fork already, [which passed and can be viewed here](https://github.com/gemmellr/artemis-examples/actions/runs/20303944462).